### PR TITLE
Add better contrast color for vertico completion highlights

### DIFF
--- a/zeno-theme.el
+++ b/zeno-theme.el
@@ -161,6 +161,9 @@
  `(hl-line ((t (:background ,hl-line-highlight))))
  `(lazy-highlight ((t (:foreground ,full-black :background ,lavender-blue))))
 
+ ;; Text color of the higlighted part
+ `(completions-common-part ((t (:foreground ,cranberry))))
+
  ;; isearch
  `(isearch ((t (:foreground ,full-black :background ,lavender-blue))))
  `(isearch-fail ((t (:foreground ,full-white :background ,warning-bg-face))))


### PR DESCRIPTION
The default font color for completion lists makes vertico difficult to read. See screenshot:

![image](https://user-images.githubusercontent.com/22661/144338339-1a7e4fa4-6fe9-4cb9-a9c4-8bb7af1872a8.png)
